### PR TITLE
GitQuery 3.0.6

### DIFF
--- a/Formula/git-query.rb
+++ b/Formula/git-query.rb
@@ -1,8 +1,8 @@
 class GitQuery < Formula
   desc "Query, Copy and Sync files from a remote Git repo"
   homepage "https://github.com/Tinder/GitQuery"
-  url "https://github.com/Tinder/GitQuery/archive/3.0.5.tar.gz"
-  sha256 "828ef6c3f71ae46c17213a7996e6fe239f575ca645b597ce4a38ed55bfad17b4"
+  url "https://github.com/Tinder/GitQuery/archive/3.0.6.tar.gz"
+  sha256 "992286c54530c941ccb1c85a7fdff8cb56af310f8915aa995d0069116bf1b382"
   
   depends_on "openjdk@8"
 


### PR DESCRIPTION
updates `brew install tinder/tap/git-query`.
to use when already installed we can use `brew upgrade tinder/tap/git-query`